### PR TITLE
CMS: add metadata to horizaccordion items

### DIFF
--- a/shared/scss/components/common/horizaccordion.scss
+++ b/shared/scss/components/common/horizaccordion.scss
@@ -61,6 +61,7 @@
     border-left: 1px solid rgba(255,255,255,0.6);
 
     .horizaccordion__text,
+    .horizaccordion__meta,
     .horizaccordion__footer .btn {
       opacity: 0;
       display: block;
@@ -81,6 +82,7 @@
           }
 
           .horizaccordion__text,
+          .horizaccordion__meta,
           .horizaccordion__footer .btn {
             opacity: 1;
             transition: opacity .3s ease-in-out .1s;
@@ -130,8 +132,34 @@
   }
 }
 
+.horizaccordion__meta {
+  color: $brand-secondary;
+  margin-bottom: $base*2;
+  z-index: 2;
+  position: relative;
+}
 
+.horizaccordion__meta {
 
+  * {
+    color: $brand-secondary;
+  }
+
+  span {
+    margin-right: $base*0.5;
+  }
+
+  a {
+    margin: 0 $base*0.5;
+    padding-bottom: 2px;
+    border-bottom: 1px solid transparent;
+
+    &:hover {
+      color: $brand-secondary-light;
+      border-color: $brand-secondary-light;
+    }
+  }
+}
 
 .horizaccordion__title {
   font-size: 2rem;

--- a/sixodp/partials/horizaccordion.php
+++ b/sixodp/partials/horizaccordion.php
@@ -28,6 +28,16 @@
                       <?php the_title(); ?>
                     </a>
                   </h4>
+                  <div class="horizaccordion__meta">
+                    <span><?php echo parse_date(get_the_date()); ?></span>
+                      <?php 
+                        if ( count(get_the_category()) > 0 ) {
+                          foreach ( get_the_category() as $cat ) { ?>
+                            | <a href="<?php echo $cat->slug; ?>"><?php echo $cat->name; ?></a><?php
+                          }
+                        }
+                      ?>
+                  </div>
                   <div class="horizaccordion__text">
                     <?php the_excerpt(); ?>
                   </div>


### PR DESCRIPTION
Add metadata and category links to horizaccordion (or "haitarielementti" in finnish) items on the frontpage.

![screenshot 2017-04-04 11 04 32](https://cloud.githubusercontent.com/assets/4393910/24646964/859f4b08-1926-11e7-8b0b-fdb94aeb5529.png)
