### PR TITLE
Redirect /qa without trailing slash to /qa/

### DIFF
--- a/ansible/roles/nginx/templates/nginx_site_config.j2
+++ b/ansible/roles/nginx/templates/nginx_site_config.j2
@@ -32,6 +32,10 @@ server {
     rewrite ^/qa/(.*)$ /qa/index.php?qa-rewrite=$1 last;
   }
 
+  location = /qa {
+    return 302 /qa/;
+  }
+
   location /qa/ {
     alias /opt/question2answer/;
     try_files $uri $uri/ @qa;


### PR DESCRIPTION
Normally nginx does this automatically if proxy_pass, fastcgi_pass, uwsgi_pass,
scgi_pass, or memcached_pass is used inside the location block. The sublocation
used for PHP apparently does not trigger this behaviour.